### PR TITLE
Add game over functionality and health management

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="hackyeah_game"
-run/main_scene="uid://ds0b1i8v4nitv"
+run/main_scene="uid://d0mco1flblvnt"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.svg"
 

--- a/scenes/demo_level.tscn
+++ b/scenes/demo_level.tscn
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://uuyrgijiy03b" path="res://scenes/wall1.tscn" id="8_freo2"]
 [ext_resource type="PackedScene" uid="uid://c7bds2o1i4ho4" path="res://scenes/wall2.tscn" id="9_6wx8f"]
 [ext_resource type="PackedScene" uid="uid://duk6jtds2icjt" path="res://scenes/wall.tscn" id="10_r34ug"]
+[ext_resource type="PackedScene" uid="uid://cd8v6h3ymxk3u" path="res://scenes/game_over.tscn" id="11_game_over"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_2vmhc"]
 shader = ExtResource("2_2vmhc")
@@ -615,5 +616,7 @@ position = Vector2(19, -471)
 position = Vector2(-91, -982)
 
 [node name="bg_music" parent="." instance=ExtResource("3_freo2")]
+
+[node name="GameOver" parent="." instance=ExtResource("11_game_over")]
 
 [editable path="Wall"]

--- a/scenes/game_over.tscn
+++ b/scenes/game_over.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=2 format=3 uid="uid://cd8v6h3ymxk3u"]
+
+[ext_resource type="Script" path="res://scripts/game_over.gd" id="1_game_over"]
+
+[node name="GameOver" type="CanvasLayer"]
+script = ExtResource("1_game_over")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.8)
+
+[node name="CenterContainer" type="CenterContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
+layout_mode = 2
+
+[node name="GameOverLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 72
+text = "GAME OVER"
+horizontal_alignment = 1
+
+[node name="ScoreLabel" type="Label" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 36
+text = "Score: 0"
+horizontal_alignment = 1
+
+[node name="Spacer" type="Control" parent="CenterContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+
+[node name="RestartButton" type="Button" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Restart"
+
+[node name="QuitButton" type="Button" parent="CenterContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 32
+text = "Quit"
+
+[connection signal="pressed" from="CenterContainer/VBoxContainer/RestartButton" to="." method="_on_restart_button_pressed"]
+[connection signal="pressed" from="CenterContainer/VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/scenes/player.gdshader
+++ b/scenes/player.gdshader
@@ -9,6 +9,7 @@ uniform float spread_strength : hint_range(0.0, 2.0) = 1.0; // how far pixels fl
 uniform float distortion_strength : hint_range(0.0, 0.2) = 0.05; // wavy distortion
 
 uniform float fade_start : hint_range(0.0, 1.0) = 0.7; // when to start fading alpha
+uniform float health_fill : hint_range(0.0, 1.0) = 0.0; // 0.0 = puste (100% życia), 1.0 = pełne (0% życia)
 
 
 
@@ -67,6 +68,33 @@ void fragment() {
     float alpha_factor = 1.0 - smoothstep(fade_start, 1.0, burst_progress);
 
     tex.a *= alpha_factor;
+    
+    // Health bar - fills the gray interior from bottom with white, keeping colorful border
+    // health_fill: 0.0 = full health (100%), 1.0 = no health (0%)
+    if (health_fill > 0.0 && tex.a > 0.1) {
+        float vertical_position = UV.y; // 0.0 = top, 1.0 = bottom
+        float health_threshold = 1.0 - health_fill;
+
+        // Detect if pixel is part of the dark/gray interior (not the colorful border)
+        float brightness = (tex.r + tex.g + tex.b) / 3.0;
+        float saturation = max(max(tex.r, tex.g), tex.b) - min(min(tex.r, tex.g), tex.b);
+
+        // Dark gray interior has low brightness and low saturation
+        bool is_interior = brightness < 0.4 && saturation < 0.3;
+
+        // Fill from bottom up based on missing health
+        if (vertical_position >= health_threshold && is_interior) {
+            // Pure white fill with subtle edge glow
+            float edge_dist = vertical_position - health_threshold;
+            float edge_glow = smoothstep(0.08, 0.0, edge_dist);
+
+            vec3 fill_color = vec3(1.0); // Pure white
+            fill_color = mix(fill_color, vec3(1.2), edge_glow * 0.5); // Slight glow at edge
+
+            // Fill with white only the interior
+            tex.rgb = mix(tex.rgb, fill_color, 0.95);
+        }
+    }
 
     COLOR = tex;
 

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -10,6 +10,7 @@ shader_parameter/burst_progress = 0.082000003895
 shader_parameter/spread_strength = 0.0
 shader_parameter/distortion_strength = 0.1970000093575
 shader_parameter/fade_start = 1.0
+shader_parameter/health_fill = 0.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_g2els"]
 radius = 21.0

--- a/scripts/demo_level.gd
+++ b/scripts/demo_level.gd
@@ -11,6 +11,7 @@ func _ready() -> void:
 	if player:
 		player.movement_stopped.connect(_on_player_stopped)
 		player.movement_started.connect(_on_player_started)
+		player.health_depleted.connect(_on_player_death)
 
 	# Start with movables slowed down since player starts stopped
 	MovableManager.apply_slowdown_all()
@@ -85,3 +86,8 @@ func _on_player_stopped() -> void:
 
 func _on_player_started() -> void:
 	MovableManager.remove_slowdown_all()
+
+func _on_player_death() -> void:
+	var game_over = get_node("GameOver")
+	if game_over:
+		game_over.show_game_over(0)

--- a/scripts/game_over.gd
+++ b/scripts/game_over.gd
@@ -1,0 +1,23 @@
+extends CanvasLayer
+
+@onready var score_label: Label = $CenterContainer/VBoxContainer/ScoreLabel
+
+var score: int = 0
+
+func _ready() -> void:
+	hide()
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
+func show_game_over(final_score: int = 0) -> void:
+	score = final_score
+	score_label.text = "Score: %d" % score
+	show()
+	get_tree().paused = true
+
+func _on_restart_button_pressed() -> void:
+	get_tree().paused = false
+	MovableManager.despawn_all()
+	get_tree().reload_current_scene()
+
+func _on_quit_button_pressed() -> void:
+	get_tree().quit()

--- a/scripts/game_over.gd.uid
+++ b/scripts/game_over.gd.uid
@@ -1,0 +1,1 @@
+uid://dpmmfymxryu3c

--- a/scripts/movable.gd
+++ b/scripts/movable.gd
@@ -23,7 +23,6 @@ func setup(texture_resource: Texture2D, new_speed: float, new_velocity: Vector2,
 	if new_velocity.length() > 0.0:
 		$Sprite2D.rotation = new_velocity.angle() + 135
 	# Debug log
-	print("Movable.setup: Rotating sprite to angle: ", new_velocity.angle(), " and ", $Sprite2D.rotation)
 
 func _ready() -> void:
 	if projectile_velocity != Vector2.ZERO:
@@ -41,10 +40,12 @@ func _on_body_entered(body: Node) -> void:
 	if body is StaticBody2D:
 		split_projectile()
 	if body is CharacterBody2D:
-		# here emit signal to play sound
 		emit_signal("collision", body, body.global_position, Vector2.ZERO)
 		call_deferred("_deferred_despawn")
 
+		body.take_damage(10)
+		if body.get_health_percentage() <= 0.0:
+			body.health_depleted.emit()
 
 
 func split_projectile() -> void:

--- a/scripts/movable_manager.gd
+++ b/scripts/movable_manager.gd
@@ -54,9 +54,11 @@ func get_active_count() -> int:
 func apply_slowdown_all() -> void:
 	is_paused = true
 	for movable in active_movables:
-		movable.apply_slowdown()
+		if is_instance_valid(movable):
+			movable.apply_slowdown()
 
 func remove_slowdown_all() -> void:
 	is_paused = false
 	for movable in active_movables:
-		movable.remove_slowdown()
+		if is_instance_valid(movable):
+			movable.remove_slowdown()


### PR DESCRIPTION
- Updated project.godot to change the main scene.
- Added game_over.tscn scene with UI elements for game over display.
- Implemented game_over.gd script to manage game over logic and UI updates.
- Modified demo_level.gd to connect player death signal to game over display.
- Enhanced player.gd with health management, including damage handling and health display updates.
- Updated movable_manager.gd to ensure valid instances before applying effects.